### PR TITLE
Correct package.json target paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "scrypt-native",
   "description": "Scrypt for Node.js using crypto.scrypt",
-  "version": "1.0.1",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "version": "1.0.2",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "license": "ISC",
   "author": "Frank Paulo Filho",
   "devDependencies": {


### PR DESCRIPTION
The version on npm wasn't working for me, it looks like the dist paths weren't specified correctly. I've fixed it in this PR.

In the meantime, this functional version can be used via `npm install kaytwo/node-scrypt-native#v1.0.2`.